### PR TITLE
NEW Added composer self-update to Travis Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ matrix:
 
 before_script:
  - phpenv rehash
+ - composer self-update
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
  - cd ~/builds/ss


### PR DESCRIPTION
This one caught me out today. Travis runs an old version of composer which doesn't play nice with composer's new version constraints.