### PR TITLE
ENHANCEMENT: Allow for suggested packages to be installed via a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ before_script:
 script: 
  - vendor/bin/phpunit <yourmodule>/tests/
 ```
+If you wish to optionally add the packages suggested by a module, pass a flag ```install-suggested yes``` to
+the line that executes travis-support.
+```
+before_script:
+ - phpenv rehash
+ - composer self-update
+ - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+ - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --install-suggested=yes
+ - cd ~/builds/ss
+```
 
 When getting set up, to avoid repeatedly pushing to trigger the service hook, you should [save time by linting your configuration with Travis WebLint](https://lint.travis-ci.org/).
 

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -33,7 +33,8 @@ $opts = getopt('', array(
 	'source:', // Required: Path to the module root directory
 	'target:', // Required: Path to where the environment will be built
 	'config:', // Optional: Location to custom mysite/_config.php to use
-	'require:' // Optional: Additional composer requirement. E.g. --require silverstripe/behat-extension:dev-master
+	'require:', // Optional: Additional composer requirement. E.g. --require silverstripe/behat-extension:dev-master
+	'install-suggested:' // Optional: Install the modules suggested packages
 ));
 
 // Sanity checks


### PR DESCRIPTION
It is possible to upload multiple coverages for one build to codecov.io, this is useful for two reasons
* Running multiple tests in parallel which would otherwise go past the 50 minute job allocation
* Running the same tests with different modules installed.
Whilst the latter can be done manually it is much better if it can be automated and sent to Travis.  One example I came across recently was checking for the existence of the Translatable module.  Another is the use of HTMLPurifier in the comments module.

This pull request adds the following optional flag:
```install-suggested yes``` to the the line that sets up Travis prior to executing tests on a SilverStripe module.
```
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --install-suggested yes
```
A working example can be found here https://github.com/gordonbanderson/silverstripe-comments/blob/testing/.travis.yml, with Travis build results here https://travis-ci.org/gordonbanderson/silverstripe-comments/builds/101808872 - whlst there are still some failed tests, those required the HTML Purifier package now work as a result of being able to install suggested packages.