### PR TITLE
FIX: Allow Multiple Package Install via Multiple --require Flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,30 @@ language: php
 
 sudo: false
 
+before_install:
+  - pip install --user codecov
+
 php:
   - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
  - composer self-update || true
  - composer install
 
 script: 
- - "vendor/bin/phpunit tests"
+ - "vendor/bin/phpunit --coverage-clover=coverage.clover tests"
+
+after_success:
+	# Move coverage into originally checkout git folder, this is required so
+	# that third party services know which commit to associate the coverage with
+  - mv coverage.clover ~/build/$TRAVIS_REPO_SLUG/
+  - cd ~/build/$TRAVIS_REPO_SLUG
+
+  # Upload coverage to Scrutinizer
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  
+  # Upload coverage to Codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ script:
  - "vendor/bin/phpunit --coverage-clover=coverage.clover tests"
 
 after_success:
-	# Move coverage into originally checkout git folder, this is required so
-	# that third party services know which commit to associate the coverage with
+  # Move coverage into originally checkout git folder, this is required so
+  # that third party services know which commit to associate the coverage with
   - mv coverage.clover ~/build/$TRAVIS_REPO_SLUG/
   - cd ~/build/$TRAVIS_REPO_SLUG
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,28 @@ After you committed the files, as a final step you'll want to enable your module
 The first builds should start within a few minutes.
 
 As a bonus, you can include build status images in your README to promote the fact that
-your module values quality and does continuous integration. 
+your module values quality and does continuous integration.
+
+## Adding extra modules
+
+If you need to add extra modules during setup, that aren't explicitly included in the module
+composer requirements, you can use the `--require` parameter.
+
+E.g.
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension
+    
+You can also specify multiple modules by either comma separating the names, or
+by the addition of multiple ``--require`` flags. Each name can also be suffixed
+with `:<version>` to add a version dependency.
+
+E.g.
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension:dev-master --require silverstripe-cms:4.0.x-dev
+
+or equivalently
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension:dev-master,silverstripe-cms:4.0.x-dev
 
 ## PDO DB Connectors
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Travis Integration for SilverStripe Modules
 [![Build Status](https://travis-ci.org/gordonbanderson/silverstripe-travis-support.svg?branch=multiple_require_options)](https://travis-ci.org/gordonbanderson/silverstripe-travis-support)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/quality-score.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/?branch=multiple_require_options)
-[![Code Coverage](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/coverage.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/?branch=multiple_require_options)
 [![Build Status](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/build.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/build-status/multiple_require_options)
 [![codecov.io](https://codecov.io/github/gordonbanderson/silverstripe-travis-support/coverage.svg?branch=multiple_require_options)](https://codecov.io/github/gordonbanderson/silverstripe-travis-support?branch=multiple_require_options)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # Travis Integration for SilverStripe Modules
+[![Build Status](https://travis-ci.org/gordonbanderson/silverstripe-travis-support.svg?branch=multiple_require_options)](https://travis-ci.org/gordonbanderson/silverstripe-travis-support)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/quality-score.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/?branch=multiple_require_options)
+[![Code Coverage](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/coverage.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/?branch=multiple_require_options)
+[![Build Status](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/build.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/build-status/multiple_require_options)
+[![codecov.io](https://codecov.io/github/gordonbanderson/silverstripe-travis-support/coverage.svg?branch=multiple_require_options)](https://codecov.io/github/gordonbanderson/silverstripe-travis-support?branch=multiple_require_options)
 
-[![Build Status](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support.svg)](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support)
+[![Latest Stable Version](https://poser.pugx.org/silverstripe/travis-support/version)](https://packagist.org/packages/silverstripe/travis-support)
+[![Latest Unstable Version](https://poser.pugx.org/silverstripe/travis-support/v/unstable)](//packagist.org/packages/silverstripe/travis-support)
+[![Total Downloads](https://poser.pugx.org/silverstripe/travis-support/downloads)](https://packagist.org/packages/silverstripe/travis-support)
+[![License](https://poser.pugx.org/silverstripe/travis-support/license)](https://packagist.org/packages/silverstripe/travis-support)
+[![Monthly Downloads](https://poser.pugx.org/silverstripe/travis-support/d/monthly)](https://packagist.org/packages/silverstripe/travis-support)
+[![Daily Downloads](https://poser.pugx.org/silverstripe/travis-support/d/daily)](https://packagist.org/packages/silverstripe/travis-support)
+
+[![Dependency Status](https://www.versioneye.com/php/silverstripe:travis-support/badge.svg)](https://www.versioneye.com/php/silverstripe:travis-support)
+[![Reference Status](https://www.versioneye.com/php/silverstripe:travis-support/reference_badge.svg?style=flat)](https://www.versioneye.com/php/silverstripe:travis-support/references)
+
+![codecov.io](https://codecov.io/github/gordonbanderson/silverstripe-travis-support/branch.svg?branch=multiple_require_options)
 
 ## Introduction
 
@@ -12,7 +27,6 @@ there's a bit of setup work required on top of the standard [Composer](http://ge
 
 The scripts allow you to test across multiple branches, and rewrite the `composer.json` to match dependencies.
 The scripts will test your module against multiple core releases, as well as multiple databases (if supported).
-See it in action on the ["translatable" module](https://travis-ci.org/silverstripe/silverstripe-translatable/).
 
 Why bother? Because it shows your users that you care about the quality of your codebase,
 and gives them a clear picture of the current status of it. And it helps you manage the complexity

--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 [![Build Status](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/badges/build.png?b=multiple_require_options)](https://scrutinizer-ci.com/g/gordonbanderson/silverstripe-travis-support/build-status/multiple_require_options)
 [![codecov.io](https://codecov.io/github/gordonbanderson/silverstripe-travis-support/coverage.svg?branch=multiple_require_options)](https://codecov.io/github/gordonbanderson/silverstripe-travis-support?branch=multiple_require_options)
 
-[![Latest Stable Version](https://poser.pugx.org/silverstripe/travis-support/version)](https://packagist.org/packages/silverstripe/travis-support)
-[![Latest Unstable Version](https://poser.pugx.org/silverstripe/travis-support/v/unstable)](//packagist.org/packages/silverstripe/travis-support)
-[![Total Downloads](https://poser.pugx.org/silverstripe/travis-support/downloads)](https://packagist.org/packages/silverstripe/travis-support)
-[![License](https://poser.pugx.org/silverstripe/travis-support/license)](https://packagist.org/packages/silverstripe/travis-support)
-[![Monthly Downloads](https://poser.pugx.org/silverstripe/travis-support/d/monthly)](https://packagist.org/packages/silverstripe/travis-support)
-[![Daily Downloads](https://poser.pugx.org/silverstripe/travis-support/d/daily)](https://packagist.org/packages/silverstripe/travis-support)
-
-[![Dependency Status](https://www.versioneye.com/php/silverstripe:travis-support/badge.svg)](https://www.versioneye.com/php/silverstripe:travis-support)
-[![Reference Status](https://www.versioneye.com/php/silverstripe:travis-support/reference_badge.svg?style=flat)](https://www.versioneye.com/php/silverstripe:travis-support/references)
-
 ![codecov.io](https://codecov.io/github/gordonbanderson/silverstripe-travis-support/branch.svg?branch=multiple_require_options)
 
 ## Introduction

--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -222,10 +222,17 @@ class ComposerGenerator {
 			// this allows for arguments like "silverstripe/behat-extension:dev-master" where "dev-master" would be the branch
 			// to use for that requirement. If just specifying "silverstripe/behat-extension" without the separator, default
 			// to the branch being "*"
-			$requireParts = explode(':', $options['require']);
-			$requireName = $requireParts[0];
-			$requireBranch = (isset($requireParts[1])) ? $requireParts[1] : '*';
-			$composer['require'][$requireName] = $requireBranch;
+
+			// If a single value is passed it's a string, if multiple then an array
+			// This ensure that $required is always an array
+			$requiredPackages = is_string($options['require']) ? array($options['require']) : $options['require'];
+
+			foreach ($requiredPackages as $requiredPackage) {
+				$requireParts = explode(':', $requiredPackage);
+				$requireName = $requireParts[0];
+				$requireBranch = (isset($requireParts[1])) ? $requireParts[1] : '*';
+				$composer['require'][$requireName] = $requireBranch;
+			}
 		}
 		return $composer;
 	}

--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -224,7 +224,17 @@ class ComposerGenerator {
 			// to the branch being "*"
 
 			// If a single value is passed it's a string, if multiple then an array
+			// In the string case check for commas, if so assume it's CSV splitting of packages
 			// This ensure that $required is always an array
+			$requiredPackages = $options['require'];
+			if (is_string($options['require'])) {
+				// if a comma is present split the CSV
+				if (strpos($options['require'], ',') !== false) {
+					$options['require'] = split(',', $options['require']);
+				}
+			} else {
+				$requiredPackages = $options['require'];
+			}
 			$requiredPackages = is_string($options['require']) ? array($options['require']) : $options['require'];
 
 			foreach ($requiredPackages as $requiredPackage) {
@@ -254,6 +264,7 @@ class ComposerGenerator {
 		// Handle custom options
 		$rootComposer = $this->mergeCustomOptions($options, $rootComposer);
 
+
 		// Update framework / cms requirements
 		$rootComposer = $this->mergeFrameworkRequirements($rootComposer, $moduleComposer);
 
@@ -271,7 +282,10 @@ class ComposerGenerator {
 	 */
 	public function mergeFrameworkRequirements($rootComposer, $moduleComposer) {
 		$coreConstraint = $this->getCoreComposerConstraint();
-		
+		error_log('Core version:' . $this->coreVersion);
+		error_log('Version compare:' . version_compare($this->coreVersion, '3'));
+		error_log('Module name:' . $moduleComposer['name']);
+
 		// Force 2.x framework dependencies to also require cms.
 		if($this->coreVersion != 'master'
 			&& version_compare($this->coreVersion, '3') < 0

--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -228,9 +228,9 @@ class ComposerGenerator {
 			// This ensure that $required is always an array
 			$requiredPackages = $options['require'];
 			if (is_string($options['require'])) {
-				// if a comma is present split the CSV
+				// if a comma is present expldoe the CSV
 				if (strpos($options['require'], ',') !== false) {
-					$options['require'] = split(',', $options['require']);
+					$options['require'] = explode(',', $options['require']);
 				}
 			} else {
 				$requiredPackages = $options['require'];

--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -150,7 +150,7 @@ class ComposerGenerator {
 		);
 
 		// If installing from a local archive, specify it
-		if($installFromPath) {
+		if($installFromPath !== null) {
 			$composerConfig = array_replace_recursive(
 				$composerConfig,
 				array(
@@ -282,9 +282,6 @@ class ComposerGenerator {
 	 */
 	public function mergeFrameworkRequirements($rootComposer, $moduleComposer) {
 		$coreConstraint = $this->getCoreComposerConstraint();
-		error_log('Core version:' . $this->coreVersion);
-		error_log('Version compare:' . version_compare($this->coreVersion, '3'));
-		error_log('Module name:' . $moduleComposer['name']);
 
 		// Force 2.x framework dependencies to also require cms.
 		if($this->coreVersion != 'master'

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -300,8 +300,6 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$result = $generator->generateComposerConfig('/home/root/builds/ss/subsites.tar');
-
-		$this->generateAssertionsFromArrayRecurse($result);
 		$expected = array(
 			'repositories' => array(
 				'0' => array(
@@ -538,8 +536,6 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-
-
 	/**
 	 * Test custom options works when an array of required packages is provided
 	 */
@@ -565,11 +561,7 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
 		);
 
-		$requiredPackages = array(
-			'silverstripe/subsites:dev-master',
-			'silverstripe/comments:2.0.2',
-			'silverstripe/tagfield:1.2.1'
-		);
+		$requiredPackages = 'silverstripe/subsites:dev-master,silverstripe/comments:2.0.2,silverstripe/tagfield:1.2.1';
 		$this->assertEquals(
 			array(
 				'require' => array(
@@ -654,57 +646,4 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 		$this->assertEquals($expected, $generator->generateComposerConfig($options));
 	}
-
-    public function generateAssertionsFromArray($toAssert)
-    {
-        echo '$expected = array('."\n";
-        foreach ($toAssert as $key => $value) {
-            $escValue = str_replace("'", '\\\'', $value);
-            echo "'$key' => '$escValue',\n";
-        }
-        echo ");\n";
-        echo '$this->assertEquals($expected, $somevar);'."\n";
-    }
-
-    public function generateAssertionsFromArray1D($toAssert)
-    {
-        echo '$expected = array('."\n";
-        foreach ($toAssert as $key => $value) {
-            $escValue = str_replace("'", '\\\'', $value);
-            echo "'$escValue',";
-        }
-        echo ");\n";
-        echo '$this->assertEquals($expected, $somevar);'."\n";
-    }
-
-    public function generateAssertionsFromArrayRecurse($toAssert)
-    {
-        echo '$expected = ';
-        $this->recurseArrayAssertion($toAssert, 1, 'FIXME');
-        echo '$this->assertEquals($expected, $somevar);'."\n";
-    }
-
-    private function recurseArrayAssertion($toAssert, $depth, $parentKey)
-    {
-        $prefix = str_repeat("\t", $depth);
-        echo "\t{$prefix}'$parentKey' => array(\n";
-        $ctr = 0;
-        $len = sizeof(array_keys($toAssert));
-        foreach ($toAssert as $key => $value) {
-            if (is_array($value)) {
-                $this->recurseArrayAssertion($value, $depth + 1, $key);
-            } else {
-                $escValue = str_replace("'", '\\\'', $value);
-                $comma = ',';
-                if ($ctr == $len - 1) {
-                    $comma = '';
-                }
-                echo "\t\t$prefix'$key' => '$escValue'$comma\n";
-            }
-
-            ++$ctr;
-        }
-        echo "\t$prefix),\n";
-    }
-
 }

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -330,4 +330,78 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
 		);
 	}
+
+
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testGenerateConfig() {
+		$frameworkComposer = $this->getMockFrameworkJson();
+
+		$generator = new ComposerGenerator(
+			'master',
+			'master',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('subsites-master')
+		);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2',
+			'silverstripe/tagfield:1.2.1'
+		);
+
+		$options = array(
+			'require' => $requiredPackages,
+			'source' => '/home/user/checkout/travis/silverstripe/comments',
+ 			'target' => '/home/user/builds/ss'
+		);
+
+		$expected = array(
+			'repositories' => array(
+				0 => array(
+					'type' => 'package',
+					'package' => array(
+						'name' => 'silverstripe/subsites',
+						'type' => 'silverstripe-module',
+						'require' => array(
+							'silverstripe/framework' => '~3.2',
+							'silverstripe/cms' => '~3.2'
+						),
+						'extra' => array(
+							'branch-alias' => array('dev-master' => '1.1.x-dev')
+						),
+						'version' => 'dev-master'
+					)
+				)
+			),
+			'require' => array(
+				'silverstripe/subsites' => 'dev-master',
+				'silverstripe/framework' => '4.0.x-dev',
+				'silverstripe/cms' => '4.0.x-dev',
+				'silverstripe/comments' => '2.0.2',
+				'silverstripe/tagfield' => '1.2.1',
+				'silverstripe-themes/simple' => '*'
+			),
+			'require-dev' => array(
+				'silverstripe/postgresql' => '*',
+				'silverstripe/sqlite3' => '*',
+				'phpunit/PHPUnit' => '~3.7@stable'
+			),
+			'minimum-stability' => 'dev',
+			'config' => array(
+				'notify-on-install' => false,
+				'process-timeout' => 600
+			)
+		);
+		$this->assertEquals($expected, $generator->generateComposerConfig($options));
+	}
 }

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -461,10 +461,11 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
+
 	/**
 	 * Test custom options works with one package required
 	 */
-	public function testMergeCustomOptionsArrayOneRequired() {
+	public function testMergeCustomOptionsArrayAndStringOneRequired() {
 		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
 
 		$base = array(
@@ -508,6 +509,51 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 			'silverstripe/subsites:dev-master',
 			'silverstripe/comments:2.0.2'
 		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2',
+			'silverstripe/tagfield:1.2.1'
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2',
+					'silverstripe/tagfield' => '1.2.1'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+	}
+
+
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testMergeCustomOptionsStringMoreThanOneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		// Expressed as CSV instead of separate --require options
+		$requiredPackages = 'silverstripe/subsites:dev-master,silverstripe/comments:2.0.2';
 		$this->assertEquals(
 			array(
 				'require' => array(

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -235,9 +235,30 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Test custom options works
+	 * Test custom options works with one package required
 	 */
-	public function testMergeCustomOptions() {
+	public function testMergeCustomOptionsArrayNoneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1'
+				)
+			),
+			$generator->mergeCustomOptions(array(), $base)
+		);
+	}
+
+	/**
+	 * Test custom options works with one package required
+	 */
+	public function testMergeCustomOptionsArrayOneRequired() {
 		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
 
 		$base = array(
@@ -262,6 +283,51 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 				)
 			),
 			$generator->mergeCustomOptions(array('require' => 'silverstripe/translatable'), $base)
+		);
+	}
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testMergeCustomOptionsArrayMoreThanOneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2'
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2',
+			'silverstripe/tagfield:1.2.1'
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2',
+					'silverstripe/tagfield' => '1.2.1'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
 		);
 	}
 }

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -457,6 +457,15 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 			),
 			$generator->mergeCustomOptions(array(), $base)
 		);
+
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1'
+				)
+			),
+			$generator->mergeCustomOptions('', $base)
+		);
 	}
 
 

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -284,6 +284,128 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/*
+	Test a condition where framework < 3 as the module required
+	 */
+	public function testMergeFramework24() {
+		$frameworkComposer = $this->getMockFrameworkJson();
+
+		// Test subsites/master (1.1) vs framework/3 (3.2)
+		$generator = new ComposerGenerator(
+			'2,4',
+			'master',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('silverstripe-framework')
+		);
+
+		$result = $generator->generateComposerConfig('/home/root/builds/ss/subsites.tar');
+
+		$this->generateAssertionsFromArrayRecurse($result);
+		$expected = array(
+			'repositories' => array(
+				'0' => array(
+					'type' => 'package',
+					'package' => array(
+						'name' => 'silverstripe/framework',
+						'type' => 'silverstripe-module',
+						'description' => 'The SilverStripe framework',
+						'homepage' => 'http://silverstripe.org',
+						'license' => 'BSD-3-Clause',
+						'keywords' => array(
+							'0' => 'silverstripe',
+							'1' => 'framework'
+						),
+						'authors' => array(
+							'0' => array(
+								'name' => 'SilverStripe',
+								'homepage' => 'http://silverstripe.com'
+							),
+							'1' => array(
+								'name' => 'The SilverStripe Community',
+								'homepage' => 'http://silverstripe.org'
+							),
+						),
+						'require' => array(
+							'php' => '>=5.5.0',
+							'composer/installers' => '~1.0',
+							'monolog/monolog' => '~1.11',
+							'league/flysystem' => '~1.0.12',
+							'symfony/yaml' => '~2.7'
+						),
+						'require-dev' => array(
+							'phpunit/PHPUnit' => '~3.7'
+						),
+						'extra' => array(
+							'branch-alias' => array(
+								'dev-master' => '4.0.x-dev'
+							),
+						),
+						'autoload' => array(
+							'classmap' => array(
+								'0' => 'tests/behat/features/bootstrap'
+							),
+						),
+						'version' => 'dev-2,4'
+					),
+				),
+			),
+			'require' => array(
+				'silverstripe/framework' => 'dev-2,4 as dev-2,4',
+				'php' => '>=5.5.0',
+				'composer/installers' => '~1.0',
+				'monolog/monolog' => '~1.11',
+				'league/flysystem' => '~1.0.12',
+				'symfony/yaml' => '~2.7',
+				'silverstripe/cms' => 'dev-2,4',
+				'silverstripe-themes/blackcandy' => '*'
+			),
+			'require-dev' => array(
+				'silverstripe/postgresql' => '*',
+				'silverstripe/sqlite3' => '*',
+				'phpunit/PHPUnit' => '~3.7'
+			),
+			'minimum-stability' => 'dev',
+			'config' => array(
+				'notify-on-install' => '',
+				'process-timeout' => '600'
+			),
+		);
+
+
+		$this->assertEquals(
+			$expected,
+			$result
+		);
+
+		// Test subsites/1.0 vs framework/3.1 (3.1)
+		$generator = new ComposerGenerator(
+			'3.1',
+			'1.0',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('subsites-1.0')
+		);
+
+		$result = $generator->generatePackageComposerConfig('/home/root/builds/ss/subsites.tar');
+		$this->assertEquals(
+			array(
+				'name' => 'silverstripe/subsites',
+				'type' => 'silverstripe-module',
+				'require' => array(
+					'silverstripe/framework' => '~3.1.0',
+					'silverstripe/cms' => '~3.1.0'
+				),
+				'version' => '1.0.x-dev',
+				'dist' => array(
+					'type' => 'tar',
+					'url' => 'file:///home/root/builds/ss/subsites.tar'
+				)
+			),
+			$result
+		);
+	}
+
 	/**
 	 * Test that requirements from packaged composer are copied to root level
 	 */
@@ -415,8 +537,6 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-
-
 	/**
 	 * Test custom options works when an array of required packages is provided
 	 */
@@ -488,8 +608,6 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 		$this->assertEquals($expected, $generator->generateComposerConfig($options));
 	}
-
-
 
     public function generateAssertionsFromArray($toAssert)
     {

--- a/tests/silverstripe-framework.json
+++ b/tests/silverstripe-framework.json
@@ -1,0 +1,36 @@
+{
+	"name": "silverstripe/framework",
+	"type": "silverstripe-module",
+	"description": "The SilverStripe framework",
+	"homepage": "http://silverstripe.org",
+	"license": "BSD-3-Clause",
+	"keywords": ["silverstripe", "framework"],
+	"authors": [
+		{
+			"name": "SilverStripe",
+			"homepage": "http://silverstripe.com"
+		},
+		{
+			"name": "The SilverStripe Community",
+			"homepage": "http://silverstripe.org"
+		}
+	],
+	"require": {
+		"php": ">=5.5.0",
+		"composer/installers": "~1.0",
+		"monolog/monolog": "~1.11",
+		"league/flysystem": "~1.0.12",
+		"symfony/yaml": "~2.7"
+	},
+	"require-dev": {
+		"phpunit/PHPUnit": "~3.7"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "4.0.x-dev"
+		}
+	},
+	"autoload": {
+		"classmap": ["tests/behat/features/bootstrap"]
+	}
+}

--- a/tests/silverstripe-reports.json
+++ b/tests/silverstripe-reports.json
@@ -1,0 +1,23 @@
+{
+	"name": "silverstripe/reports",
+	"type": "silverstripe-module",
+	"homepage": "http://silverstripe.org",
+	"license": "BSD-3-Clause",
+	"keywords": ["silverstripe", "cms", "reports"],
+	"authors": [{
+		"name": "SilverStripe",
+		"homepage": "http://silverstripe.com"
+	}, {
+		"name": "The SilverStripe Community",
+		"homepage": "http://silverstripe.org"
+	}],
+	"require": {
+		"php": ">=5.3.3",
+		"silverstripe/framework": ">=3.1.x-dev"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "4.0.x-dev"
+		}
+	}
+}


### PR DESCRIPTION
This appears to be similar to https://github.com/silverstripe-labs/silverstripe-travis-support/pull/22, which I only noticed afterwards, but uses multiple --require flags which I think is cleaner.  For example:

```
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require "ezyang/htmlpurifier:4.*" --require "silverstripe/cms:~3.1"
```

A working example Travis build can be seen here, https://travis-ci.org/gordonbanderson/silverstripe-comments/jobs/102044501

If you think this an appropriate way to go @tractorcow I will add relevant unit tests