### PR TITLE
Install Multiple Packages Prior to Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,30 @@ language: php
 
 sudo: false
 
+before_install:
+  - pip install --user codecov
+
 php:
   - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
  - composer self-update || true
  - composer install
 
 script: 
- - "vendor/bin/phpunit tests"
+ - "vendor/bin/phpunit --coverage-clover=coverage.clover tests"
+
+after_success:
+  # Move coverage into originally checkout git folder, this is required so
+  # that third party services know which commit to associate the coverage with
+  - mv coverage.clover ~/build/$TRAVIS_REPO_SLUG/
+  - cd ~/build/$TRAVIS_REPO_SLUG
+
+  # Upload coverage to Scrutinizer
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  
+  # Upload coverage to Codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Travis Integration for SilverStripe Modules
+[![Build Status](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support.svg?branch=master)](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe-labs/silverstripe-travis-support/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe-labs/silverstripe-travis-support/?branch=master)
+[![Build Status](https://scrutinizer-ci.com/g/silverstripe-labs/silverstripe-travis-support/badges/build.png?b=master)](https://scrutinizer-ci.com/g/silverstripe-labs/silverstripe-travis-support/build-status/master)
+[![codecov.io](https://codecov.io/github/silverstripe-labs/silverstripe-travis-support/coverage.svg?branch=master)](https://codecov.io/github/silverstripe-labs/silverstripe-travis-support?branch=master)
 
-[![Build Status](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support.svg)](https://travis-ci.org/silverstripe-labs/silverstripe-travis-support)
+![codecov.io](https://codecov.io/github/silverstripe-labs/silverstripe-travis-support/branch.svg?branch=master)
 
 ## Introduction
 
@@ -12,7 +16,6 @@ there's a bit of setup work required on top of the standard [Composer](http://ge
 
 The scripts allow you to test across multiple branches, and rewrite the `composer.json` to match dependencies.
 The scripts will test your module against multiple core releases, as well as multiple databases (if supported).
-See it in action on the ["translatable" module](https://travis-ci.org/silverstripe/silverstripe-translatable/).
 
 Why bother? Because it shows your users that you care about the quality of your codebase,
 and gives them a clear picture of the current status of it. And it helps you manage the complexity
@@ -107,7 +110,28 @@ After you committed the files, as a final step you'll want to enable your module
 The first builds should start within a few minutes.
 
 As a bonus, you can include build status images in your README to promote the fact that
-your module values quality and does continuous integration. 
+your module values quality and does continuous integration.
+
+## Adding extra modules
+
+If you need to add extra modules during setup, that aren't explicitly included in the module
+composer requirements, you can use the `--require` parameter.
+
+E.g.
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension
+    
+You can also specify multiple modules by either comma separating the names, or
+by the addition of multiple ``--require`` flags. Each name can also be suffixed
+with `:<version>` to add a version dependency.
+
+E.g.
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension:dev-master --require silverstripe-cms:4.0.x-dev
+
+or equivalently
+
+    php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension:dev-master,silverstripe-cms:4.0.x-dev
 
 ## PDO DB Connectors
 

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -201,6 +201,210 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test that the package sub-section of the composer config is generated properly
+	 */
+	public function testGeneratePackageConfigCoreModule() {
+		$frameworkComposer = $this->getMockFrameworkJson();
+
+		// Test subsites/master (1.1) vs framework/3 (3.2)
+		$generator = new ComposerGenerator(
+			'3',
+			'master',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('silverstripe-reports')
+		);
+
+		$result = $generator->generatePackageComposerConfig('/home/root/builds/ss/subsites.tar');
+		$expected = array(
+			'name' => 'silverstripe/reports',
+			'type' => 'silverstripe-module',
+			'homepage' => 'http://silverstripe.org',
+			'license' => 'BSD-3-Clause',
+			'keywords' => array(
+				'0' => 'silverstripe',
+				'1' => 'cms',
+				'2' => 'reports'
+			),
+			'authors' => array(
+				'0' => array(
+					'name' => 'SilverStripe',
+					'homepage' => 'http://silverstripe.com'
+				),
+				'1' => array(
+					'name' => 'The SilverStripe Community',
+					'homepage' => 'http://silverstripe.org'
+				),
+			),
+			'require' => array(
+				'php' => '>=5.3.3',
+				'silverstripe/framework' => '>=3.1.x-dev'
+			),
+			'extra' => array(
+				'branch-alias' => array(
+					'dev-master' => '4.0.x-dev'
+				),
+			),
+			'version' => '3.2.x-dev',
+			'dist' => array(
+				'type' => 'tar',
+				'url' => 'file:///home/root/builds/ss/subsites.tar'
+			),
+		);
+		$this->assertEquals(
+			$expected,
+			$result
+		);
+
+		// Test subsites/1.0 vs framework/3.1 (3.1)
+		$generator = new ComposerGenerator(
+			'3.1',
+			'1.0',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('subsites-1.0')
+		);
+
+		$result = $generator->generatePackageComposerConfig('/home/root/builds/ss/subsites.tar');
+		$this->assertEquals(
+			array(
+				'name' => 'silverstripe/subsites',
+				'type' => 'silverstripe-module',
+				'require' => array(
+					'silverstripe/framework' => '~3.1.0',
+					'silverstripe/cms' => '~3.1.0'
+				),
+				'version' => '1.0.x-dev',
+				'dist' => array(
+					'type' => 'tar',
+					'url' => 'file:///home/root/builds/ss/subsites.tar'
+				)
+			),
+			$result
+		);
+	}
+
+	/*
+	Test a condition where framework < 3 as the module required
+	 */
+	public function testMergeFramework24() {
+		$frameworkComposer = $this->getMockFrameworkJson();
+
+		// Test subsites/master (1.1) vs framework/3 (3.2)
+		$generator = new ComposerGenerator(
+			'2,4',
+			'master',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('silverstripe-framework')
+		);
+
+		$result = $generator->generateComposerConfig('/home/root/builds/ss/subsites.tar');
+		$expected = array(
+			'repositories' => array(
+				'0' => array(
+					'type' => 'package',
+					'package' => array(
+						'name' => 'silverstripe/framework',
+						'type' => 'silverstripe-module',
+						'description' => 'The SilverStripe framework',
+						'homepage' => 'http://silverstripe.org',
+						'license' => 'BSD-3-Clause',
+						'keywords' => array(
+							'0' => 'silverstripe',
+							'1' => 'framework'
+						),
+						'authors' => array(
+							'0' => array(
+								'name' => 'SilverStripe',
+								'homepage' => 'http://silverstripe.com'
+							),
+							'1' => array(
+								'name' => 'The SilverStripe Community',
+								'homepage' => 'http://silverstripe.org'
+							),
+						),
+						'require' => array(
+							'php' => '>=5.5.0',
+							'composer/installers' => '~1.0',
+							'monolog/monolog' => '~1.11',
+							'league/flysystem' => '~1.0.12',
+							'symfony/yaml' => '~2.7'
+						),
+						'require-dev' => array(
+							'phpunit/PHPUnit' => '~3.7'
+						),
+						'extra' => array(
+							'branch-alias' => array(
+								'dev-master' => '4.0.x-dev'
+							),
+						),
+						'autoload' => array(
+							'classmap' => array(
+								'0' => 'tests/behat/features/bootstrap'
+							),
+						),
+						'version' => 'dev-2,4'
+					),
+				),
+			),
+			'require' => array(
+				'silverstripe/framework' => 'dev-2,4 as dev-2,4',
+				'php' => '>=5.5.0',
+				'composer/installers' => '~1.0',
+				'monolog/monolog' => '~1.11',
+				'league/flysystem' => '~1.0.12',
+				'symfony/yaml' => '~2.7',
+				'silverstripe/cms' => 'dev-2,4',
+				'silverstripe-themes/blackcandy' => '*'
+			),
+			'require-dev' => array(
+				'silverstripe/postgresql' => '*',
+				'silverstripe/sqlite3' => '*',
+				'phpunit/PHPUnit' => '~3.7'
+			),
+			'minimum-stability' => 'dev',
+			'config' => array(
+				'notify-on-install' => '',
+				'process-timeout' => '600'
+			),
+		);
+
+
+		$this->assertEquals(
+			$expected,
+			$result
+		);
+
+		// Test subsites/1.0 vs framework/3.1 (3.1)
+		$generator = new ComposerGenerator(
+			'3.1',
+			'1.0',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('subsites-1.0')
+		);
+
+		$result = $generator->generatePackageComposerConfig('/home/root/builds/ss/subsites.tar');
+		$this->assertEquals(
+			array(
+				'name' => 'silverstripe/subsites',
+				'type' => 'silverstripe-module',
+				'require' => array(
+					'silverstripe/framework' => '~3.1.0',
+					'silverstripe/cms' => '~3.1.0'
+				),
+				'version' => '1.0.x-dev',
+				'dist' => array(
+					'type' => 'tar',
+					'url' => 'file:///home/root/builds/ss/subsites.tar'
+				)
+			),
+			$result
+		);
+	}
+
+	/**
 	 * Test that requirements from packaged composer are copied to root level
 	 */
 	public function testRootRequirements() {
@@ -235,9 +439,40 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Test custom options works
+	 * Test custom options works with one package required
 	 */
-	public function testMergeCustomOptions() {
+	public function testMergeCustomOptionsArrayNoneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1'
+				)
+			),
+			$generator->mergeCustomOptions(array(), $base)
+		);
+
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1'
+				)
+			),
+			$generator->mergeCustomOptions('', $base)
+		);
+	}
+
+
+	/**
+	 * Test custom options works with one package required
+	 */
+	public function testMergeCustomOptionsArrayAndStringOneRequired() {
 		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
 
 		$base = array(
@@ -263,5 +498,161 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 			),
 			$generator->mergeCustomOptions(array('require' => 'silverstripe/translatable'), $base)
 		);
+	}
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testMergeCustomOptionsArrayMoreThanOneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2'
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2',
+			'silverstripe/tagfield:1.2.1'
+		);
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2',
+					'silverstripe/tagfield' => '1.2.1'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+	}
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testMergeCustomOptionsStringMoreThanOneRequired() {
+		$generator = new ComposerGenerator('master', 'master', ComposerGenerator::REF_BRANCH);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		// Expressed as CSV instead of separate --require options
+		$requiredPackages = 'silverstripe/subsites:dev-master,silverstripe/comments:2.0.2';
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+
+		$requiredPackages = 'silverstripe/subsites:dev-master,silverstripe/comments:2.0.2,silverstripe/tagfield:1.2.1';
+		$this->assertEquals(
+			array(
+				'require' => array(
+					'silverstripe/framework' => '~3.1',
+					'silverstripe/subsites' => 'dev-master',
+					'silverstripe/comments' => '2.0.2',
+					'silverstripe/tagfield' => '1.2.1'
+				)
+			),
+			$generator->mergeCustomOptions(array('require' => $requiredPackages), $base)
+		);
+	}
+
+	/**
+	 * Test custom options works when an array of required packages is provided
+	 */
+	public function testGenerateConfig() {
+		$frameworkComposer = $this->getMockFrameworkJson();
+
+		$generator = new ComposerGenerator(
+			'master',
+			'master',
+			ComposerGenerator::REF_BRANCH,
+			$frameworkComposer,
+			$this->getMockModuleJson('subsites-master')
+		);
+
+		$base = array(
+			'require' => array(
+				'silverstripe/framework' => '~3.1'
+			)
+		);
+
+		$requiredPackages = array(
+			'silverstripe/subsites:dev-master',
+			'silverstripe/comments:2.0.2',
+			'silverstripe/tagfield:1.2.1'
+		);
+
+		$options = array(
+			'require' => $requiredPackages,
+			'source' => '/home/user/checkout/travis/silverstripe/comments',
+ 			'target' => '/home/user/builds/ss'
+		);
+
+		$expected = array(
+			'repositories' => array(
+				0 => array(
+					'type' => 'package',
+					'package' => array(
+						'name' => 'silverstripe/subsites',
+						'type' => 'silverstripe-module',
+						'require' => array(
+							'silverstripe/framework' => '~3.2',
+							'silverstripe/cms' => '~3.2'
+						),
+						'extra' => array(
+							'branch-alias' => array('dev-master' => '1.1.x-dev')
+						),
+						'version' => 'dev-master'
+					)
+				)
+			),
+			'require' => array(
+				'silverstripe/subsites' => 'dev-master',
+				'silverstripe/framework' => '4.0.x-dev',
+				'silverstripe/cms' => '4.0.x-dev',
+				'silverstripe/comments' => '2.0.2',
+				'silverstripe/tagfield' => '1.2.1',
+				'silverstripe-themes/simple' => '*'
+			),
+			'require-dev' => array(
+				'silverstripe/postgresql' => '*',
+				'silverstripe/sqlite3' => '*',
+				'phpunit/PHPUnit' => '~3.7@stable'
+			),
+			'minimum-stability' => 'dev',
+			'config' => array(
+				'notify-on-install' => false,
+				'process-timeout' => 600
+			)
+		);
+		$this->assertEquals($expected, $generator->generateComposerConfig($options));
 	}
 }

--- a/tests/silverstripe-framework.json
+++ b/tests/silverstripe-framework.json
@@ -1,0 +1,36 @@
+{
+	"name": "silverstripe/framework",
+	"type": "silverstripe-module",
+	"description": "The SilverStripe framework",
+	"homepage": "http://silverstripe.org",
+	"license": "BSD-3-Clause",
+	"keywords": ["silverstripe", "framework"],
+	"authors": [
+		{
+			"name": "SilverStripe",
+			"homepage": "http://silverstripe.com"
+		},
+		{
+			"name": "The SilverStripe Community",
+			"homepage": "http://silverstripe.org"
+		}
+	],
+	"require": {
+		"php": ">=5.5.0",
+		"composer/installers": "~1.0",
+		"monolog/monolog": "~1.11",
+		"league/flysystem": "~1.0.12",
+		"symfony/yaml": "~2.7"
+	},
+	"require-dev": {
+		"phpunit/PHPUnit": "~3.7"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "4.0.x-dev"
+		}
+	},
+	"autoload": {
+		"classmap": ["tests/behat/features/bootstrap"]
+	}
+}

--- a/tests/silverstripe-reports.json
+++ b/tests/silverstripe-reports.json
@@ -1,0 +1,23 @@
+{
+	"name": "silverstripe/reports",
+	"type": "silverstripe-module",
+	"homepage": "http://silverstripe.org",
+	"license": "BSD-3-Clause",
+	"keywords": ["silverstripe", "cms", "reports"],
+	"authors": [{
+		"name": "SilverStripe",
+		"homepage": "http://silverstripe.com"
+	}, {
+		"name": "The SilverStripe Community",
+		"homepage": "http://silverstripe.org"
+	}],
+	"require": {
+		"php": ">=5.3.3",
+		"silverstripe/framework": ">=3.1.x-dev"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "4.0.x-dev"
+		}
+	}
+}


### PR DESCRIPTION
This follows on from https://github.com/silverstripe-labs/silverstripe-travis-support/pull/24 which I've just closed.  It allows for extra packages to be installed prior to running tests by adding an extra parameter(s) to the command travis_setup.php command of the form:

```
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require "ezyang/htmlpurifier:4.*,silverstripe/cms:~3.1"
```
or equivalently
```
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require "ezyang/htmlpurifier:4.* --require silverstripe/cms:~3.1"
```

Being able to install the extra packages allows for a scenario where a module is tested both with and without an external dependency, for example a module may do different things dependent on whether Translatable is installed or not.  External services such as codecov amalgamate coverage from multiple runs, which makes 100% code coverage possible.

I've added badges to the README as per https://github.com/gordonbanderson/silverstripe-travis-support/tree/multiple_require_options but with the paths set for the main branch and repository.

Successful Travis builds with the two different formats for passing extra required packages:
* Required packages as comma separated https://travis-ci.org/gordonbanderson/silverstripe-comments/jobs/102764940
* Required packages as multiple --require options https://travis-ci.org/gordonbanderson/silverstripe-comments/jobs/102763780
