### PR TITLE
API Include hidden files when generating module archive

### DIFF
--- a/travis_setup.php
+++ b/travis_setup.php
@@ -131,7 +131,7 @@ echo "$composerStr\n\n";
  */
 run("cd $modulePath");
 
-run("tar -cf $moduleArchivePath ./*");
+run("tar -cf $moduleArchivePath * .??*");
 
 run("git clone --depth=100 --quiet -b $coreBranch git://github.com/silverstripe/silverstripe-installer.git $targetPath");
 


### PR DESCRIPTION
Fixes #21

Solution taken from http://superuser.com/questions/85699/tar-how-to-ignore-the-archive-itself