### PR TITLE
Alias and custom installer branch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ env:
     - DB=MYSQL CORE_RELEASE=3.2
   ```
 
+## Working with Pull Requests
+
+The logic relies on pulling in different core releases based on the `CORE_RELEASE` constant.
+This can lead to inconsistencies where pull requests rely on other branches,
+for example where a pull request for the `cms` module relies on an equivalent in the `framework` module.
+While there's no clean way to tell Travis which branches to use, temporary modifications
+to `travis.yml` can help prove a build is passing with the right dependencies.
+
+ * Add custom fork `repositories` to your module's `composer.json`. They'll get pulled up into the root `composer.json` automatically
+ * Set the `CORE_RELEASE` environment variable to the branch name on your fork.
+ * Create branches with the same name on both `cms` and `framework` modules
+ * Either create a branch on `installer`, or set a different `CORE_INSTALLER_RELEASE` environment variable
+ * Set a `CORE_ALIAS` environment variable in order to satisfy 
+   [constrains](https://getcomposer.org/doc/articles/aliases.md) (e.g. `4.0.x-dev`)
+
+Note that these `.travis.yml` changes in your fork are temporary,
+and need to be reverted before the pull request will be merged.
+Unfortunately Travis CI doesn't support per-build configuration settings
+outside of version control.
+
 ## Github Rate Limitation
 
 Composer heavily relies on github's APIs for retrieving repository info and downloading archives.

--- a/src/ComposerGenerator.php
+++ b/src/ComposerGenerator.php
@@ -25,6 +25,14 @@ class ComposerGenerator {
 	protected $coreVersion = null;
 
 	/**
+	 * Composer inline alias version to use for {@link coreVersion}.
+	 * @see https://getcomposer.org/doc/articles/aliases.md
+	 *
+	 * @var string
+	 */
+	protected $coreAlias = null;
+
+	/**
 	 * Version of the module to use
 	 *
 	 * @var string
@@ -81,6 +89,18 @@ class ComposerGenerator {
 	}
 
 	/**
+	 * @param string $alias Support for inline aliases of {@link $coreVersion}.
+	 * @see https://getcomposer.org/doc/articles/aliases.md
+	 * @return self
+	 */
+	public function setCoreAlias($alias)
+	{
+		$this->coreAlias = $alias;
+
+		return $this;
+	}
+
+	/**
 	 * Parse a version in a form appropriate for a composer constraint
 	 *
 	 * @param string $version Version
@@ -122,6 +142,11 @@ class ComposerGenerator {
 		// Respect branch alias in core
 		if( isset( $this->corePackageInfo['package']['versions'][$version]['extra']['branch-alias'][$version])) {
 			return $this->corePackageInfo['package']['versions'][$version]['extra']['branch-alias'][$version];
+		}
+
+		// Respect branch alias configured externally
+		if ($this->coreAlias) {
+			$version .= ' as ' . $this->coreAlias;
 		}
 		
 		return $version;

--- a/tests/ComposerGeneratorTest.php
+++ b/tests/ComposerGeneratorTest.php
@@ -43,6 +43,11 @@ class ComposerGeneratorTest extends PHPUnit_Framework_TestCase {
 		$generator = new ComposerGenerator('3.2', '1.1.0', ComposerGenerator::REF_TAG);
 		$this->assertEquals('1.1.0', $generator->getModuleComposerConstraint());
 		$this->assertEquals('3.2.x-dev', $generator->getCoreComposerConstraint());
+
+		$generator = new ComposerGenerator('master', '1.1', ComposerGenerator::REF_BRANCH);
+		$generator->setCoreAlias('2.0.x-dev');
+		$this->assertEquals('1.1.x-dev', $generator->getModuleComposerConstraint());
+		$this->assertEquals('dev-master as 2.0.x-dev', $generator->getCoreComposerConstraint());
 	}
 
 	/**

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -65,6 +65,7 @@ if(!getenv('TRAVIS_TAG') && !getenv('TRAVIS_BRANCH')) {
 }
 
 $coreBranch = getenv('CORE_RELEASE');
+$coreAlias = getenv('CORE_ALIAS');
 $moduleVersion = getenv('TRAVIS_TAG') ?: getenv('TRAVIS_BRANCH');
 $moduleRef = getenv('TRAVIS_TAG')
 	? ComposerGenerator::REF_TAG
@@ -118,6 +119,10 @@ $composerGenerator = new ComposerGenerator(
 	$corePackageInfo,
 	$modulePackageInfo
 );
+
+if($coreAlias) {
+	$composerGenerator->setCoreAlias($coreAlias);
+}
 
 $moduleArchivePath = "$parent/$moduleName.tar";
 $composer = $composerGenerator->generateComposerConfig($opts, $moduleArchivePath);

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -65,6 +65,7 @@ if(!getenv('TRAVIS_TAG') && !getenv('TRAVIS_BRANCH')) {
 }
 
 $coreBranch = getenv('CORE_RELEASE');
+$coreInstallerBranch = getenv('CORE_INSTALLER_RELEASE') ? getenv('CORE_INSTALLER_RELEASE') : $coreBranch;
 $coreAlias = getenv('CORE_ALIAS');
 $moduleVersion = getenv('TRAVIS_TAG') ?: getenv('TRAVIS_BRANCH');
 $moduleRef = getenv('TRAVIS_TAG')
@@ -138,7 +139,7 @@ run("cd $modulePath");
 
 run("tar -cf $moduleArchivePath * .??*");
 
-run("git clone --depth=100 --quiet -b $coreBranch git://github.com/silverstripe/silverstripe-installer.git $targetPath");
+run("git clone --depth=100 --quiet -b $coreInstallerBranch git://github.com/silverstripe/silverstripe-installer.git $targetPath");
 
 run("cp $dir/_ss_environment.php $targetPath/_ss_environment.php");
 if($configPath) run("cp $configPath $targetPath/mysite/_config.php");


### PR DESCRIPTION
Required to get new `asset-admin` module building with our long-running forks of framework and cms (until the module is stable in about a month). Relies on a `repositories` key to be merged from the module `composer.json` to the dynamically generated root `composer.json`, which is already the case in the current logic. The aliasing is necessary to avoid failing composer constraint checks. Could also be solved via `branch-alias` on the forks of course, but that's more CI-related code which needs to be removed before opening a pull request.

I purposely haven't documented this feature since it's weakening the API a bit (unclear where `CORE_RELEASE` is enforce). If you think it's a feature we should draw attention to, I'm happy to document in README