### PR TITLE
Fix composer api token use

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1,6 +1,6 @@
 <?php
-function run($cmd) {
-	echo "+ $cmd\n";
+function run($cmd, $echo = true) {
+	if($echo) echo "+ $cmd\n";
 	passthru($cmd, $returnVar);
 	if($returnVar > 0) die($returnVar);
 }

--- a/travis_setup.php
+++ b/travis_setup.php
@@ -91,10 +91,8 @@ if(
 	// Defaults to unencrypted tokens, so we don't need to exclude pull requests
 	// && (!getenv('TRAVIS_PULL_REQUEST') || getenv('TRAVIS_PULL_REQUEST') == 'false')
 ) {
-	$composerGlobalConf = array('config' => array('github-oauth' => array('github.com' => getenv('GITHUB_API_TOKEN'))));
-	$composerConfDir = getenv("HOME") . '/.composer/';
-	if(!file_exists($composerConfDir)) mkdir($composerConfDir);
-	file_put_contents($composerConfDir . '/config.json', json_encode($composerGlobalConf));
+	// Set the token without echo'ing the command to keep it secure
+	run('composer config -g github-oauth.github.com ' . getenv('GITHUB_API_TOKEN'), false);
 	echo "Using GITHUB_API_TOKEN...\n";
 }
 


### PR DESCRIPTION
Was using an internal JSON structure which composer has changed
in the meantime - it now writes to a separate auth.json file.

Using the documented approach instead, see https://getcomposer.org/doc/articles/troubleshooting.md#api-rate-limit-and-oauth-tokens