### PR TITLE
Add support for --prefer-source Composer argument

### DIFF
--- a/travis_setup.php
+++ b/travis_setup.php
@@ -30,10 +30,11 @@ $defaults = array(
  * 1. Check and parse command line options
  */
 $opts = getopt('', array(
-	'source:', // Required: Path to the module root directory
-	'target:', // Required: Path to where the environment will be built
-	'config:', // Optional: Location to custom mysite/_config.php to use
-	'require:' // Optional: Additional composer requirement. E.g. --require silverstripe/behat-extension:dev-master
+	'source:',      // Required: Path to the module root directory
+	'target:',      // Required: Path to where the environment will be built
+	'config:',      // Optional: Location to custom mysite/_config.php to use
+	'require:',     // Optional: Additional composer requirement. E.g. --require silverstripe/behat-extension:dev-master
+	'prefer-source' // Optional: Prefer source (i.e. version control repository) when running composer install
 ));
 
 // Sanity checks
@@ -48,6 +49,7 @@ $targetPath = $opts['target'];
 $modulePath = $opts['source'];
 $moduleName = basename($modulePath);
 $parent = dirname($modulePath);
+$installType = (isset($opts['prefer-source'])) ? '--prefer-source' : '--prefer-dist';
 
 /**
  * 2. Check and parse environment variables
@@ -150,7 +152,7 @@ if(file_exists("$targetPath/composer.lock")) {
 	run("rm $targetPath/composer.lock");
 }
 
-run("cd ~ && composer install --no-ansi --prefer-dist -d $targetPath");
+run("cd ~ && composer install --no-ansi $installType -d $targetPath");
 
 /**
  * 8. Installer doesn't work out of the box without cms - delete the Page class if its not required


### PR DESCRIPTION
Note: this didn’t actually solve the problem below for me (as `--prefer-source` failed and fell back to dist, I’m looking into why - I think it may be a caching thing), but I thought this might be worth proposing anyway.

--

Problem: I have two packages, lets say **Package A** and **Package B**. **Package A** has a `tests/TestCase.php`, **Package B** depends on **Package A** and **Package B’s** test classes extend **Package A’s** `TestCase`:

```php
// ./package-a/tests
class TestCase extends SapphireTest {
}

// ./package-b/tests
class SomeTest extends TestCase {
}
```

*N.b: I’m not sure if this is a strange pattern? Doesn’t seem unreasonable to me...*

If **Package A** has a `.gitattributes` that excludes the `tests` directory from exports, then `composer install --prefer-dist` will not include that directory either, so **Package B’s** tests will fail as `TestCase` doesn’t exist.

This PR adds the option to use `--prefer-source` for Composer installs, which clones the git repo so will include everything (it defaults to the current behaviour of `--prefer-dist`).